### PR TITLE
fix event and notice fetching based on selected language

### DIFF
--- a/MementoMori.BlazorShared/Pages/Index.razor
+++ b/MementoMori.BlazorShared/Pages/Index.razor
@@ -465,10 +465,12 @@
         }
     }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        base.OnInitialized();
+        await base.OnInitializedAsync();
         _ = CheckLatestVersion();
+
+        await Funcs.GetNoticeInfoList(AccountManager.CurrentCulture);
     }
 
     private void ShowNotice(NoticeInfo context)

--- a/MementoMori.BlazorShared/Pages/Index.razor
+++ b/MementoMori.BlazorShared/Pages/Index.razor
@@ -387,7 +387,7 @@
                 <Header>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.Center">
                         <MudSpacer/>
-                        <MudButton Size="Size.Small" Variant="Variant.Filled" @onclick="() => Funcs.GetNoticeInfoList(AccountManager.CurrentCulture)">@ResourceStrings.Sync</MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" @onclick="@Funcs.GetNoticeInfoList">@ResourceStrings.Sync</MudButton>
                     </MudStack>
                 </Header>
                 <ChildContent>
@@ -470,7 +470,7 @@
         await base.OnInitializedAsync();
         _ = CheckLatestVersion();
 
-        await Funcs.GetNoticeInfoList(AccountManager.CurrentCulture);
+        _ = Funcs.GetNoticeInfoList();
     }
 
     private void ShowNotice(NoticeInfo context)

--- a/MementoMori.BlazorShared/Pages/Index.razor
+++ b/MementoMori.BlazorShared/Pages/Index.razor
@@ -387,7 +387,7 @@
                 <Header>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.Center">
                         <MudSpacer/>
-                        <MudButton Size="Size.Small" Variant="Variant.Filled" @onclick="@Funcs.GetNoticeInfoList">@ResourceStrings.Sync</MudButton>
+                        <MudButton Size="Size.Small" Variant="Variant.Filled" @onclick="() => Funcs.GetNoticeInfoList(AccountManager.CurrentCulture)">@ResourceStrings.Sync</MudButton>
                     </MudStack>
                 </Header>
                 <ChildContent>

--- a/MementoMori/MementoMoriFuncs.Ops.cs
+++ b/MementoMori/MementoMoriFuncs.Ops.cs
@@ -50,6 +50,7 @@ using ShopGetListRequest = MementoMori.Ortega.Share.Data.ApiInterface.Shop.GetLi
 using ShopGetListResponse = MementoMori.Ortega.Share.Data.ApiInterface.Shop.GetListResponse;
 using TradeShopGetListRequest = MementoMori.Ortega.Share.Data.ApiInterface.TradeShop.GetListRequest;
 using TradeShopGetListResponse = MementoMori.Ortega.Share.Data.ApiInterface.TradeShop.GetListResponse;
+using System.Globalization;
 using System.Xml.Linq;
 using MementoMori.Common.Localization;
 using MementoMori.MagicOnion;
@@ -1954,9 +1955,12 @@ public partial class MementoMoriFuncs : ReactiveObject
         MonthlyLoginBonusInfo = response;
     }
 
-    public async Task GetNoticeInfoList()
+    public async Task GetNoticeInfoList(CultureInfo cultureInfo)
     {
+        NetworkManager.CultureInfo = cultureInfo;
+
         var countryCode = OrtegaConst.Addressable.LanguageNameDictionary[NetworkManager.LanguageType];
+
         var response = await GetResponse<GetNoticeInfoListRequest, GetNoticeInfoListResponse>(new GetNoticeInfoListRequest()
         {
             AccessType = NoticeAccessType.Title,
@@ -1974,7 +1978,10 @@ public partial class MementoMoriFuncs : ReactiveObject
             LanguageType = NetworkManager.LanguageType,
             UserId = AuthOption.UserId
         });
-        EventInfoList = response2.NoticeInfoList.Where(d=>d.Id % 10 != 6).ToList();
+        EventInfoList = response2.NoticeInfoList
+            .GroupBy(n => n.Title)
+            .Select(g => g.First())
+            .ToList();
     }
 
     public TowerType[] GetAvailableTower()

--- a/MementoMori/MementoMoriFuncs.Ops.cs
+++ b/MementoMori/MementoMoriFuncs.Ops.cs
@@ -1955,10 +1955,8 @@ public partial class MementoMoriFuncs : ReactiveObject
         MonthlyLoginBonusInfo = response;
     }
 
-    public async Task GetNoticeInfoList(CultureInfo cultureInfo)
+    public async Task GetNoticeInfoList()
     {
-        NetworkManager.CultureInfo = cultureInfo;
-
         var countryCode = OrtegaConst.Addressable.LanguageNameDictionary[NetworkManager.LanguageType];
 
         var response = await GetResponse<GetNoticeInfoListRequest, GetNoticeInfoListResponse>(new GetNoticeInfoListRequest()

--- a/MementoMori/MementoNetworkManager.cs
+++ b/MementoMori/MementoNetworkManager.cs
@@ -44,7 +44,7 @@ public partial class MementoNetworkManager : IDisposable
 
     public long UserId { get; set; }
     public long PlayerId { get; set; }
-    public CultureInfo CultureInfo { get; set; } = new("zh-CN");
+    public CultureInfo CultureInfo { get; private set; } = new("zh-CN");
     public LanguageType LanguageType => parseLanguageType(CultureInfo);
 
 
@@ -172,6 +172,7 @@ public partial class MementoNetworkManager : IDisposable
 
     public void SetCultureInfo(CultureInfo cultureInfo)
     {
+        CultureInfo = cultureInfo;
         Masters.TextResourceTable.SetLanguageType(parseLanguageType(cultureInfo));
         Masters.LoadAllMasters();
     }

--- a/MementoMori/MementoNetworkManager.cs
+++ b/MementoMori/MementoNetworkManager.cs
@@ -44,7 +44,7 @@ public partial class MementoNetworkManager : IDisposable
 
     public long UserId { get; set; }
     public long PlayerId { get; set; }
-    public CultureInfo CultureInfo { get; private set; } = new("zh-CN");
+    public CultureInfo CultureInfo { get; set; } = new("zh-CN");
     public LanguageType LanguageType => parseLanguageType(CultureInfo);
 
 


### PR DESCRIPTION
Changes made:
1. Modified event and notice fetching to use the selected language from the dropdown menu. Previously, it only fetched events and notices in Chinese, no matter what the selected language is.

2. Implemented automatic fetching of events and notices when:
   a) Initially loading the website
   b) Changing the language in the dropdown menu

Here's a preview video of the changes:

https://github.com/moonheart/mementomori-helper/assets/55097092/6964ae55-e3c3-4b1a-8455-b58fd86cac5e


I'm making this pull request to bring attention to a bug I noticed and to propose a potential fix. As I've never used C# and Blazor before this project, I recognize there might be more efficient or idiomatic ways to achieve this.

Feel free to close this pull request if you don't find my changes suitable or if you prefer to address the issue differently.

Thank you.
