### PR TITLE
fix mission activity claim and sync code from 4.19.2

### DIFF
--- a/MementoMori.Ortega/Common/Enums/ClientErrorCode.cs
+++ b/MementoMori.Ortega/Common/Enums/ClientErrorCode.cs
@@ -21,6 +21,7 @@
 		AddressableNetwork = 101,
 		AddressableStorage,
 		RawDataNetwork,
+		AddressableCacheCleaner,
 		MasterDataCatalog = 201,
 		MasterDataDownload,
 		MasterDataLoadFromLocal,
@@ -437,6 +438,8 @@
 		LuckyChanceInputFormPrefectureTextError,
 		LuckyChanceInputFormMunicipalityEmpty,
 		LuckyChanceInputFormBlockNumberEmpty,
+		LuckyChanceInputFormNotSelectedPrizeCharacter,
+		LuckyChancePrizeCharacterSettingNotSelected = 3000101,
 		BulkSphereSetMaxCustomCount = 3100001,
 		BulkSphereSetMaxCustomCountPerCharacter,
 		BulkSphereSetAlreadyTop,
@@ -480,6 +483,12 @@
 		RentalRaidChallengePeriodEnded,
 		RentalRaidMaxCoopCharactersExceeded,
 		DeepLinkTutorial = 40000001,
-		DeepLinkPurchaseState
+		DeepLinkPurchaseState,
+		MiningQuestLocked = 41000001,
+		MiningQuestReinforcementNotEnoughItem,
+		MiningQuestReinforcementMaxLevel,
+		MiningQuestReinforcementCollectionLevel,
+		MiningQuestRewardReceived,
+		MiningQuestGameStartBlocked
 	}
 }

--- a/MementoMori.Ortega/Share/Data/Chat/ChatInfo.cs
+++ b/MementoMori.Ortega/Share/Data/Chat/ChatInfo.cs
@@ -17,6 +17,9 @@ namespace MementoMori.Ortega.Share.Data.Chat
 		[Key(13)]
 		public ChatBattleInfo ChatBattleInfo { get; set; }
 
+		[Key(14)]
+		public ChatMusicPlaylistInfo ChatMusicPlaylistInfo { get; set; }
+
 		[Key(1)]
 		public ChatType ChatType { get; set; }
 

--- a/MementoMori.Ortega/Share/Data/Chat/ChatMusicPlaylistInfo.cs
+++ b/MementoMori.Ortega/Share/Data/Chat/ChatMusicPlaylistInfo.cs
@@ -1,0 +1,23 @@
+using MessagePack;
+
+namespace MementoMori.Ortega.Share.Data.Chat
+{
+	[MessagePackObject(false)]
+	public class ChatMusicPlaylistInfo
+	{
+		[Key(0)]
+		public long FirstMusicId { get; set; }
+
+		[Key(1)]
+		public long PlayerIconId { get; set; }
+
+		[Key(2)]
+		public string PlaylistName { get; set; }
+
+		[Key(3)]
+		public int MusicCount { get; set; }
+
+		[Key(4)]
+		public string PlaylistShareCode { get; set; }
+	}
+}

--- a/MementoMori.Ortega/Share/Data/DtoInfo/UserCharacterRankReleaseDtoInfo.cs
+++ b/MementoMori.Ortega/Share/Data/DtoInfo/UserCharacterRankReleaseDtoInfo.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using MessagePack;
+
+namespace MementoMori.Ortega.Share.Data.DtoInfo
+{
+	[MessagePackObject(true)]
+	public class UserCharacterRankReleaseDtoInfo
+	{
+		[Description("プレイヤーID")]
+		public long PlayerId { get; set; }
+
+		[Description("CharacterMBのID")]
+		public long CharacterId { get; set; }
+	}
+}

--- a/MementoMori.Ortega/Share/Data/DtoInfo/UserRankUpPrioritySettingDtoInfo.cs
+++ b/MementoMori.Ortega/Share/Data/DtoInfo/UserRankUpPrioritySettingDtoInfo.cs
@@ -1,0 +1,15 @@
+using MementoMori.Ortega.Share.Enums;
+using MessagePack;
+
+namespace MementoMori.Ortega.Share.Data.DtoInfo
+{
+	[MessagePackObject(true)]
+	public class UserRankUpPrioritySettingDtoInfo
+	{
+		public long PlayerId { get; set; }
+
+		public bool Enabled { get; set; }
+
+		public Dictionary<ElementType, List<long>> SettingDict { get; set; }
+	}
+}

--- a/MementoMori.Ortega/Share/Data/UserSyncData.cs
+++ b/MementoMori.Ortega/Share/Data/UserSyncData.cs
@@ -90,6 +90,8 @@ public class UserSyncData
 
     public List<ShopProductGuerrillaPack> ShopProductGuerrillaPackList { get; set; }
 
+    public long? TotalPoint { get; set; }
+
     public long StripePoint { get; set; }
 
     public long? TimeServerId { get; set; }
@@ -109,6 +111,8 @@ public class UserSyncData
     public List<UserCharacterCollectionDtoInfo> UserCharacterCollectionDtoInfos { get; set; }
 
     public List<UserCharacterDtoInfo> UserCharacterDtoInfos { get; set; }
+
+    public List<UserCharacterRankReleaseDtoInfo> UserCharacterRankReleaseDtoInfos { get; set; }
 
     public List<UserDeckDtoInfo> UserDeckDtoInfos { get; set; }
 
@@ -136,6 +140,8 @@ public class UserSyncData
     public List<UserOpenContentDtoInfo> UserOpenContentDtoInfos { get; set; }
 
     public UserFriendBattleOptionDtoInfo UserFriendBattleOptionDtoInfo { get; set; }
+
+    public UserRankUpPrioritySettingDtoInfo UserRankUpPrioritySettingDtoInfo { get; set; }
 
     public UserRecruitGuildMemberSettingDtoInfo UserRecruitGuildMemberSettingDtoInfo { get; set; }
 
@@ -225,6 +231,7 @@ public class UserSyncData
         if (userSyncData.ShopCurrencyMissionProgressMap.IsNotNullOrEmpty()) ShopCurrencyMissionProgressMap = ShopCurrencyMissionProgressMap.Merge(userSyncData.ShopCurrencyMissionProgressMap);
         if (userSyncData.ShopProductGuerrillaPackList.IsNotNullOrEmpty())
             ShopProductGuerrillaPackList = ShopProductGuerrillaPackList.Merge(userSyncData.ShopProductGuerrillaPackList, (x, y) => x.ShopGuerrillaPackId == y.ShopGuerrillaPackId);
+        if (userSyncData.TotalPoint != null) TotalPoint = userSyncData.TotalPoint;
         if (userSyncData.TimeServerId != null) TimeServerId = userSyncData.TimeServerId;
         if (userSyncData.TreasureChestCeilingCountMap.IsNotNullOrEmpty()) TreasureChestCeilingCountMap = TreasureChestCeilingCountMap.Merge(userSyncData.TreasureChestCeilingCountMap);
         if (userSyncData.UserBattleBossDtoInfo != null) UserBattleBossDtoInfo = userSyncData.UserBattleBossDtoInfo;
@@ -234,6 +241,8 @@ public class UserSyncData
         if (userSyncData.UserCharacterBookDtoInfos.IsNotNullOrEmpty()) UserCharacterBookDtoInfos = userSyncData.UserCharacterBookDtoInfos;
         if (userSyncData.UserCharacterCollectionDtoInfos.IsNotNullOrEmpty()) UserCharacterCollectionDtoInfos = userSyncData.UserCharacterCollectionDtoInfos;
         if (userSyncData.UserCharacterDtoInfos.IsNotNullOrEmpty()) UserCharacterDtoInfos = UserCharacterDtoInfos.Merge(userSyncData.UserCharacterDtoInfos, (a, b) => a.Guid == b.Guid);
+        if (userSyncData.UserCharacterRankReleaseDtoInfos.IsNotNullOrEmpty())
+            UserCharacterRankReleaseDtoInfos = UserCharacterRankReleaseDtoInfos.Merge(userSyncData.UserCharacterRankReleaseDtoInfos, (a, b) => a.CharacterId == b.CharacterId);
         if (userSyncData.UserDeckDtoInfos.IsNotNullOrEmpty()) UserDeckDtoInfos = userSyncData.UserDeckDtoInfos;
         if (userSyncData.UserEquipmentDtoInfos.IsNotNullOrEmpty()) UserEquipmentDtoInfos = UserEquipmentDtoInfos.Merge(userSyncData.UserEquipmentDtoInfos, (a, b) => a.Guid == b.Guid);
         if (userSyncData.UserItemDtoInfo.IsNotNullOrEmpty()) UserItemDtoInfo = UserItemDtoInfo.Merge(userSyncData.UserItemDtoInfo, (a, b) => a.ItemType == b.ItemType && a.ItemId == b.ItemId);
@@ -246,6 +255,7 @@ public class UserSyncData
         if (userSyncData.UserGuidanceTimeMap.IsNotNullOrEmpty()) UserGuidanceTimeMap = UserGuidanceTimeMap.Merge(userSyncData.UserGuidanceTimeMap);
         if (userSyncData.UserNotificationDtoInfoInfos.IsNotNullOrEmpty()) UserNotificationDtoInfoInfos = userSyncData.UserNotificationDtoInfoInfos;
         if (userSyncData.UserOpenContentDtoInfos.IsNotNullOrEmpty()) UserOpenContentDtoInfos = userSyncData.UserOpenContentDtoInfos;
+        if (userSyncData.UserRankUpPrioritySettingDtoInfo != null) UserRankUpPrioritySettingDtoInfo = userSyncData.UserRankUpPrioritySettingDtoInfo;
         if (userSyncData.UserSettingsDtoInfoList.IsNotNullOrEmpty()) UserSettingsDtoInfoList = userSyncData.UserSettingsDtoInfoList;
         if (userSyncData.UserShopAchievementPackDtoInfos.IsNotNullOrEmpty()) UserShopAchievementPackDtoInfos = userSyncData.UserShopAchievementPackDtoInfos;
         if (userSyncData.UserShopFirstChargeBonusDtoInfo != null) UserShopFirstChargeBonusDtoInfo = userSyncData.UserShopFirstChargeBonusDtoInfo;

--- a/MementoMori.Ortega/Share/Enums/Battle/Skill/PassiveTrigger.cs
+++ b/MementoMori.Ortega/Share/Enums/Battle/Skill/PassiveTrigger.cs
@@ -97,6 +97,10 @@ namespace MementoMori.Ortega.Share.Enums.Battle.Skill
 		AlwaysEnemyDead,
         [Description("与バフ解除時")]
         EnemyRemoveBuff,
+		[Description("自身以外の味方の与デバフ時")]
+		AllyGiveDeBuff,
+		[Description("第三者の攻撃時、味方の被攻撃時（命中時のみ）")]
+		AllyReceiveDamageHitOnly,
 		[Description("敵が攻撃した時")]
 		EnemyAttack = 50,
 		[Description("被致命的ダメージ時回復")]

--- a/MementoMori.Ortega/Share/Enums/CurrencyType.cs
+++ b/MementoMori.Ortega/Share/Enums/CurrencyType.cs
@@ -11,5 +11,6 @@ public enum CurrencyType
     [Description("有償ダイヤ(Windows)")] PaidWindows = 4,
     [Description("有償ダイヤ(DMM)")] PaidDMM,
     [Description("有償ダイヤ(Steam)")] PaidSteam,
-    [Description("有償ダイヤ(Apk)")] PaidApk
+    [Description("有償ダイヤ(Apk)")] PaidApk,
+    [Description("有償ダイヤ(Webクリスタル)")] PaidWebCrystal = 100
 }

--- a/MementoMori.Ortega/Share/Enums/ItemType.cs
+++ b/MementoMori.Ortega/Share/Enums/ItemType.cs
@@ -111,7 +111,13 @@ namespace MementoMori.Ortega.Share.Enums
         IconEffect,
         [Description("シンクロハンマー")]
         SynchroCellUnlockItem,
+        [Description("リアル景品(C)")]
+        RealPrizeC = 54,
+        [Description("マイニングクエストイベント報酬アイテム")]
+        MiningQuestEventRewardItem = 56,
         [Description("Stripeクーポン")]
-        StripeCoupon = 1001
+        StripeCoupon = 1001,
+        [Description("Webクリスタル")]
+        WebCrystal = 2001
 	}
 }

--- a/MementoMori.Ortega/Share/Enums/MaintenanceFunctionType.cs
+++ b/MementoMori.Ortega/Share/Enums/MaintenanceFunctionType.cs
@@ -85,7 +85,25 @@ namespace MementoMori.Ortega.Share.Enums
 		GuildBattleDeclaration,
 		[Description("グランドバトル布告")]
 		GrandBattleDeclaration,
+		[Description("Webストア")]
+		WebStore,
         [Description("お手伝い派遣")]
-        BookSortAssistance = 41
+        BookSortAssistance = 41,
+		[Description("Webストア(クレジットカード)")]
+		WebStoreCreditCard,
+		[Description("Webストア(Apple Pay)")]
+		WebStoreApplePay,
+		[Description("Webストア(Google Pay)")]
+		WebStoreGooglePay,
+		[Description("Webストア(Amazon Pay)")]
+		WebStoreAmazonPay,
+		[Description("Webストア(PayPay)")]
+		WebStorePayPay,
+		[Description("Webストア(d払い)")]
+		WebStoreDPay,
+		[Description("Webストア(au PAY)")]
+		WebStoreAuPay,
+		[Description("Webストア(ソフトバンクまとめて支払い)")]
+		WebStoreSoftBankPay
 	}
 }

--- a/MementoMori.Ortega/Share/Enums/MissionType.cs
+++ b/MementoMori.Ortega/Share/Enums/MissionType.cs
@@ -76,6 +76,8 @@ namespace MementoMori.Ortega.Share.Enums
 		Collab,
 		PopularityVote,
 		BookSort,
-		RentalRaid
+		RentalRaid,
+		[Description("マイニングクエスト")]
+		MiningQuest = 17
 	}
 }

--- a/MementoMori.Ortega/Share/Enums/OpenCommandType.cs
+++ b/MementoMori.Ortega/Share/Enums/OpenCommandType.cs
@@ -177,6 +177,10 @@ namespace MementoMori.Ortega.Share.Enums
 		EquipmentReset = 580,
         [Description("セレクト音楽設定")]
         SelectMusicSetting = 600,
+		[Description("Webクリスタル")]
+		WebCrystal = 610,
+		[Description("マイニングクエスト")]
+		MiningQuest = 620,
 		[Description("武具固定")]
 		LockEquipment = 1000,
 		[Description("武具固定(ギルドバトル用)")]

--- a/MementoMori.Ortega/Share/Enums/PresentType.cs
+++ b/MementoMori.Ortega/Share/Enums/PresentType.cs
@@ -52,6 +52,10 @@ namespace MementoMori.Ortega.Share.Enums
 		[Description("ラッキーチャンス")]
 		LuckyChance,
 		[Description("レンタルレイド ランキング報酬")]
-		RentalRaidRankingReward
+		RentalRaidRankingReward,
+		[Description("マイニングクエスト シーズングレード報酬")]
+		MiningQuestSeasonGradeReward,
+		[Description("Webストア購入")]
+		WebStorePurchase
 	}
 }

--- a/MementoMori.Ortega/Share/Enums/ShopProductType.cs
+++ b/MementoMori.Ortega/Share/Enums/ShopProductType.cs
@@ -28,6 +28,8 @@ namespace MementoMori.Ortega.Share.Enums
 		GuerrillaPack,
 		[Description("ミッションパス")]
 		MissionPass,
+		[Description("Webストア")]
+		WebStore,
 		[Description("全検索")]
 		AllSearch = 99
 	}

--- a/MementoMori.Ortega/Share/Enums/TransferSpotType.cs
+++ b/MementoMori.Ortega/Share/Enums/TransferSpotType.cs
@@ -99,6 +99,10 @@ namespace MementoMori.Ortega.Share.Enums
 		PlayVideo = 330,
 		[Description("レンタルレイド")]
 		RentalRaid = 340,
+		[Description("Webストアログインキャンペーン")]
+		WebStoreLoginCampaign = 350,
+		[Description("マイニングクエスト")]
+		MiningQuest = 360,
 		[Description("フレンド")]
 		Friend = 4
 	}

--- a/MementoMori.Ortega/Share/ErrorCode.cs
+++ b/MementoMori.Ortega/Share/ErrorCode.cs
@@ -137,6 +137,8 @@ namespace MementoMori.Ortega.Share
 		ItemEditorNotConsumableItem,
 		[Description("付与できないアイテムです。")]
 		ItemEditorCanNotGiveItem,
+		[Description("Webクリスタルが足りません。")]
+		ItemEditorNotEnoughWebCrystal,
 		[Description("ユーザのボックスデータが存在しません。")]
 		ItemEditorUserBoxSizeDtoNotFound = 82000,
 		[Description("ユーザーのステータスデータが存在しません。")]
@@ -169,6 +171,10 @@ namespace MementoMori.Ortega.Share
 		UserNotFoundPlayerInfo,
 		[Description("所持したことがないキャラクターは背景に設定できません。")]
 		UserInvalidBackgroundCharacterId,
+		[Description("プレイヤー名の変更が禁止されています。")]
+		UserPlayerNameChangeProhibited,
+		[Description("プレイヤーコメントの変更が禁止されています。")]
+		UserPlayerCommentChangeProhibited,
 		[Description("所持してないキャラクターです")]
 		UserSetDeckNotFoundCharacter = 93101,
 		[Description("デッキ内にキャラクターがいません。")]
@@ -211,6 +217,10 @@ namespace MementoMori.Ortega.Share
 		BattleCommonNotFoundActiveSkillConditionFormula,
 		[Description("バトル種別が無効です。")]
 		BattleCommonInvalidBattleType,
+		[Description("効果系スキルの効果最大回数データが存在しません。")]
+		BattleCommonNotFoundStatusSubSubSkillEffectMaxCountFormula,
+		[Description("効果系スキルの効果回数データが存在しません。")]
+		BattleCommonNotFoundStatusSubSubSkillEffectCountFormula,
 		[Description("ユーザーの放置バトルデータがありません")]
 		BattleAutoUserBattleAutoDtoNotFound = 101000,
 		[Description("ユーザーのボスバトルデータがありません")]
@@ -1119,6 +1129,10 @@ namespace MementoMori.Ortega.Share
 		ShopAlreadyUsedCoupon,
 		[Description("利用できない商品タイプです。")]
 		ShopNotSupportShopProductType,
+		[Description("Webクリスタルでの商品購入リクエストが不正です。")]
+		ShopBuyProductWithWebCrystalInvalidRequest = 262050,
+		[Description("支払い詳細履歴の取得リクエストが不正です。")]
+		ShopGetPaymentDetailHistoryInvaildRequest,
 		[Description("ユーザーのステータスデータが見つかりません。")]
 		ChatUserStatusDtoNotFound = 271000,
 		[Description("ユーザーのアカウントデータが見つかりません。")]
@@ -1331,6 +1345,12 @@ namespace MementoMori.Ortega.Share
 		MissionNotClearedPrevSheetMission,
 		[Description("ギルドツリーイベント終了後にギルドに加入したためミッションを開けません。")]
 		MissionJoinGuildAfterEndEvent = 352030,
+		[Description("不正なリクエストです。")]
+		MissionInvalidRequest,
+		[Description("新キャラクターミッションが開放されていません。")]
+		MissionNotOpenNewCharacterMission,
+		[Description("コラボミッションが開放されていません。")]
+		MissionNotOpenCollabMission,
 		[Description("ユーザーの放置バトルデータが存在しません。")]
 		TradeShopUserBattleAutoDtoNotFound = 361000,
 		[Description("ユーザーの放置バトルデータが存在しません。")]
@@ -1611,6 +1631,24 @@ namespace MementoMori.Ortega.Share
 		LuckyChanceContainsHalfWidthCharacterBlockNumber,
 		[Description("建物名を全角で入力してください。")]
 		LuckyChanceContainsHalfWidthCharacterBuildingName,
+		[Description("キャラクターが選択されていません。")]
+		LuckyChanceNotSelectCharacter,
+		[Description("既に選択済みのキャラクターです。")]
+		LuckyChanceCharacterAlreadySelected,
+		[Description("選択キャラクター景品が存在しません。")]
+		LuckyChanceNotExistSelectCharacterPrize,
+		[Description("住所が登録されていません。")]
+		LuckyChanceNotRegisteredAddress,
+		[Description("選択除外キャラクターです。")]
+		LuckyChanceExcludeSelectionCharacter,
+		[Description("選択されたラッキーチャンスボタンが見つかりません。")]
+		NotFoundSelectedLuckyChanceButton,
+		[Description("不正なラッキーチャンスボタンです。")]
+		InvalidLuckyChanceButton,
+		[Description("ラッキーチャンスボタンの選択は不要です。")]
+		NoNeedToSelectLuckyChanceButton,
+		[Description("現在のユーザラッキーチャンスが見つかりません。")]
+		NotFoundCurrentUserLuckyChance,
 		[Description("ユーザーのフレンド情報が見つかりません。")]
 		FriendBattleUserFriendDtoNotFound = 480000,
 		[Description("ユーザーのステータス情報が見つかりません。")]
@@ -1777,6 +1815,28 @@ namespace MementoMori.Ortega.Share
 		IconEffectLocked,
 		[Description("アイコンエフェクト設定に失敗しました。")]
 		IconEffectSetFailed = 552010,
+		[Description("ユーザーのマイニングクエストデータが見つかりません。")]
+		MiningQuestNotFoundUserMiningQuestDto = 560000,
+		[Description("マイニングクエストイベントが開催されていません。")]
+		MiningQuestEventNotHeld = 561000,
+		[Description("マイニングクエストが進行中ではありません。")]
+		MiningQuestNotProgress,
+		[Description("マイニングクエストが完了していません。")]
+		MiningQuestNotFinished,
+		[Description("強化レベルが存在しません。")]
+		MiningQuestNotExistReinforcementLevel,
+		[Description("収集レベルが不足しています。")]
+		MiningQuestNotEnoughCollectionLevel,
+		[Description("日付が変更されました。")]
+		MiningQuestChangeDay,
+		[Description("特典を解放できません。")]
+		MiningQuestUnavailableUnlockBenefit,
+		[Description("日次報酬は受け取り済みです。")]
+		MiningQuestAlreadyReceivedDailyReward,
+		[Description("日次報酬を受け取っていません。")]
+		MiningQuestNotReceivedDailyReward,
+		[Description("マイニングクエストイベントが開放されていません。")]
+		MiningQuestEventNotOpen,
 		[Description("存在しないTreasureChestです。")]
 		ItemOpenTreasureChestIdNotFound = 602004,
 		[Description("存在しないTreasureChestです。")]
@@ -2132,6 +2192,32 @@ namespace MementoMori.Ortega.Share
 		[Description("次回支払日が存在しません。")]
 		SteamNotFoundNextPayment,
 		[Description("レート制限により課金処理が失敗しました。")]
-		SteamRateLimited
+		SteamRateLimited,
+		[Description("GMO注文データが見つかりません。")]
+		GmoGmoOrderDtoNotFound = 6010000,
+		[Description("ユーザーのステータスデータが見つかりません。")]
+		GmoUserStatusDtoNotFound,
+		[Description("既に使用済みの注文です。")]
+		GmoAlreadyUsedOrder = 6011000,
+		[Description("プレゼントデータの作成に失敗しました。")]
+		GmoFailToCreatePresentData,
+		[Description("不正な通知タイプです。")]
+		GmoInvalidNoticeType,
+		[Description("不正な支払いタイプです。")]
+		GmoInvalidPayType,
+		[Description("注文IDが見つかりません。")]
+		GmoNotFoundOrderId,
+		[Description("ステータスが見つかりません。")]
+		GmoNotFoundStatus,
+		[Description("不正なトークンデータです。")]
+		GmoInvalidTokenData,
+		[Description("不正なトークン秘密鍵です。")]
+		GmoInvalidTokenPrivateKey,
+		[Description("不正な通貨コードです。")]
+		GmoInvalidCurrencyCode,
+		[Description("不正なトークン価格です。")]
+		GmoInvalidTokenPrice,
+		[Description("支払いが完了していません。")]
+		GmoNotPaid
 	}
 }

--- a/MementoMori.Ortega/Share/Master/Data/LuckyChanceMB.cs
+++ b/MementoMori.Ortega/Share/Master/Data/LuckyChanceMB.cs
@@ -36,22 +36,26 @@ namespace MementoMori.Ortega.Share.Master.Data
 		[Description("タイトルキー")]
 		public string TitleTextKey { get; }
 
-		[PropertyOrder(8)]
+		[PropertyOrder(7)]
 		[Description("同一ユーザーの抽選上限回数")]
 		public int LimitUserDrawCount { get; }
 
 		[Nest(false, 0)]
-		[PropertyOrder(9)]
+		[PropertyOrder(8)]
 		[Description("消費アイテム")]
 		public UserItem ConsumeItem { get; }
 
         [DateTimeString]
-		[PropertyOrder(10)]
+		[PropertyOrder(9)]
 		[Description("個人情報が削除可能になる日時")]
 		public string CanDeletePersonalInfoTime { get; }
 
+		[PropertyOrder(10)]
+		[Description("景品選択除外キャラId")]
+		public IReadOnlyList<long> ExcludeSelectionCharacterIdList { get; }
+
 		[SerializationConstructor]
-        public LuckyChanceMB(long id, bool? isIgnore, string memo, StartEndTimeZoneType startEndTimeZoneType, string startTime, string endTime, string inputFormEndTime, MypageIconDisplayLocationType mypageIconDisplayLocationType, string titleTextKey, int limitUserDrawCount, UserItem consumeItem, string canDeletePersonalInfoTime)
+        public LuckyChanceMB(long id, bool? isIgnore, string memo, StartEndTimeZoneType startEndTimeZoneType, string startTime, string endTime, string inputFormEndTime, MypageIconDisplayLocationType mypageIconDisplayLocationType, string titleTextKey, int limitUserDrawCount, UserItem consumeItem, string canDeletePersonalInfoTime, IReadOnlyList<long> excludeSelectionCharacterIdList)
 			: base(id, isIgnore, memo)
 		{
             this.StartEndTimeZoneType = startEndTimeZoneType;
@@ -63,6 +67,7 @@ namespace MementoMori.Ortega.Share.Master.Data
             this.LimitUserDrawCount = limitUserDrawCount;
             this.ConsumeItem = consumeItem;
             this.CanDeletePersonalInfoTime = canDeletePersonalInfoTime;
+            this.ExcludeSelectionCharacterIdList = excludeSelectionCharacterIdList;
 		}
 
 		public LuckyChanceMB()

--- a/MementoMori/Funcs/Mission.cs
+++ b/MementoMori/Funcs/Mission.cs
@@ -93,18 +93,19 @@ public partial class MementoMoriFuncs
             {
                 if (pair.Value.UserMissionActivityDtoInfo == null) continue;
 
-                foreach (var (rewardId, statusType) in pair.Value.UserMissionActivityDtoInfo.RewardStatusDict)
-                {
-                    if (statusType == MissionActivityRewardStatusType.NotReceived)
-                    {
-                        var rewardMb = TotalActivityMedalRewardTable.GetById(rewardId);
-                        log(string.Format(ResourceStrings.RewardMissionMsg, pair.Key, rewardMb.RequiredActivityMedalCount));
-                        var response = await GetResponse<RewardMissionActivityRequest, RewardMissionActivityResponse>(new RewardMissionActivityRequest
-                            {MissionGroupType = pair.Key, RequiredCount = rewardMb.RequiredActivityMedalCount});
-                        response.RewardInfo.ItemList.PrintUserItems(log);
-                        response.RewardInfo.CharacterList.PrintCharacterDtos(log);
-                    }
-                }
+                // 客户端改为一次领取最高可领档位，并自动包含此前未领的较低档位
+                var maxRequiredCount = pair.Value.UserMissionActivityDtoInfo.RewardStatusDict
+                    .Where(d => d.Value == MissionActivityRewardStatusType.NotReceived)
+                    .Select(d => TotalActivityMedalRewardTable.GetById(d.Key).RequiredActivityMedalCount)
+                    .DefaultIfEmpty(0)
+                    .Max();
+                if (maxRequiredCount <= 0) continue;
+
+                log(string.Format(ResourceStrings.RewardMissionMsg, pair.Key, maxRequiredCount));
+                var response = await GetResponse<RewardMissionActivityRequest, RewardMissionActivityResponse>(new RewardMissionActivityRequest
+                    {MissionGroupType = pair.Key, RequiredCount = maxRequiredCount});
+                response.RewardInfo.ItemList.PrintUserItems(log);
+                response.RewardInfo.CharacterList.PrintCharacterDtos(log);
             }
         });
     }

--- a/updater.sh
+++ b/updater.sh
@@ -23,8 +23,8 @@ RED="\033[0;31m"
 GREEN="\033[0;32m"
 NC="\033[0m"
 
-# 检查所需工具的可用性
-required_tools=("jq" "wget" "unzip")
+# 检查所需工具的可用性（gh 可选，用于绕过 GitHub API 匿名限流）
+required_tools=("jq" "wget" "unzip" "curl")
 missing_tools=()
 
 for tool in "${required_tools[@]}"; do
@@ -98,13 +98,33 @@ case "$arch" in
         ;;
 esac
 
-# 获取最新的发布信息
-latestRelease=$(curl -s "$releaseApiUrl")
-latestVersionStr=$(echo "$latestRelease" | jq -r '.tag_name')
+# 获取最新的发布信息（优先使用已登录的 gh，避免 GitHub API 匿名限流）
+latestVersionStr=""
+latestRelease=""
+
+if command -v gh &> /dev/null; then
+    latestVersionStr=$(gh api "repos/$repository/releases/latest" --jq .tag_name 2>/dev/null || true)
+fi
+
+if [ -z "$latestVersionStr" ] || [ "$latestVersionStr" = "null" ]; then
+    latestRelease=$(curl -sS "$releaseApiUrl" 2>/dev/null || true)
+    latestVersionStr=$(echo "$latestRelease" | jq -r '.tag_name // empty' 2>/dev/null || true)
+fi
+
+# 网页跳转兜底（API 被限流时仍可拿到 tag）
+if [ -z "$latestVersionStr" ] || [ "$latestVersionStr" = "null" ]; then
+    latestVersionStr=$(curl -sSIL "https://github.com/$repository/releases/latest" 2>/dev/null \
+        | awk 'BEGIN{IGNORECASE=1} /^location:/ {print $2}' \
+        | tr -d '\r' \
+        | sed -n 's|.*/tag/||p' \
+        | tail -n 1)
+fi
+
 latestVersion=$(echo "$latestVersionStr" | sed 's/^v//')
 
 # 检查是否成功获取最新版本信息
-if [ -z "$latestRelease" ] || [ "$latestVersionStr" = "null" ]; then
+if [ -z "$latestVersionStr" ] || [ "$latestVersionStr" = "null" ]; then
+    apiMessage=$(echo "$latestRelease" | jq -r '.message // empty' 2>/dev/null || true)
     case "$lang" in
         zh_CN|zh_SG)
             echo -e "${RED}错误：无法获取最新版本,请检查网络连接是否正常.${NC}"
@@ -119,6 +139,9 @@ if [ -z "$latestRelease" ] || [ "$latestVersionStr" = "null" ]; then
             echo -e "${RED}Error: Unable to retrieve the latest version, please check your network connection.${NC}"
             ;;
     esac
+    if [ -n "$apiMessage" ]; then
+        echo -e "${RED}$apiMessage${NC}"
+    fi
     exit 1
 fi
 
@@ -159,12 +182,45 @@ else
     # 下载最新版本的压缩包
     downloadLink="$downloadUrl/$latestVersionStr/$zipName"
     downloadPath="$downloadDirectory/latest.zip"
-    wget -O "$downloadPath" "$downloadLink"
+    if ! wget -O "$downloadPath" "$downloadLink"; then
+        case "$lang" in
+            zh_CN|zh_SG)
+                echo -e "${RED}错误：下载失败 $downloadLink${NC}"
+                ;;
+            zh_TW|zh_HK)
+                echo -e "${RED}錯誤：下載失敗 $downloadLink${NC}"
+                ;;
+            ja_JP)
+                echo -e "${RED}エラー：ダウンロードに失敗しました $downloadLink${NC}"
+                ;;
+            *)
+                echo -e "${RED}Error: Failed to download $downloadLink${NC}"
+                ;;
+        esac
+        exit 1
+    fi
 
     # 解压缩文件到临时文件夹
     tempDir="$downloadDirectory/temp"
     mkdir -p "$tempDir"
-    unzip "$downloadPath" -d "$tempDir"
+    if ! unzip "$downloadPath" -d "$tempDir"; then
+        case "$lang" in
+            zh_CN|zh_SG)
+                echo -e "${RED}错误：解压失败${NC}"
+                ;;
+            zh_TW|zh_HK)
+                echo -e "${RED}錯誤：解壓失敗${NC}"
+                ;;
+            ja_JP)
+                echo -e "${RED}エラー：解凍に失敗しました${NC}"
+                ;;
+            *)
+                echo -e "${RED}Error: Failed to unzip the archive${NC}"
+                ;;
+        esac
+        rm -rf "$tempDir" "$downloadPath"
+        exit 1
+    fi
 
     # 停止当前运行的程序
     pkill -f "$programFileName" || true


### PR DESCRIPTION
## Summary
- Fix weekly/daily mission activity reward claiming: the client now claims the highest claimable tier in one request (lower tiers are included automatically), matching current API behavior.
- Improve `updater.sh` release version detection with `gh`/curl/redirect fallbacks to reduce GitHub API rate-limit failures.
- Sync Ortega share-layer enums/DTO fields from client **4.19.2** (ErrorCode, PassiveTrigger, WebCrystal/MiningQuest/WebStore-related enums, UserSyncData, ChatMusicPlaylistInfo, LuckyChanceMB, etc.).

## Test plan
- [x] Run mission activity reward claim when multiple tiers (e.g. 20 + 40) are claimable; confirm a single successful claim and no `無法領取` / ErrorCode 352008.
- [x] Run `updater.sh` with and without logged-in `gh`; confirm latest version is resolved under API rate limit.
- [x] Smoke-test login/sync after 4.19.2 field updates (UserSyncData deserialize, chat info, LuckyChance master load).


Made with [Cursor](https://cursor.com)