### PR TITLE
fix: KeyNotFoundException aborts dungeon run on JoinCharacter grid

### DIFF
--- a/MementoMori/Funcs/DungeonBattle.cs
+++ b/MementoMori/Funcs/DungeonBattle.cs
@@ -368,7 +368,7 @@ public partial class MementoMoriFuncs
                             case DungeonBattleGridType.JoinCharacter:
                             {
                                 var characterIds = battleInfoResponse.UserDungeonDtoInfo
-                                    .GuestCharacterMap[currentGrid.Grid.DungeonGridGuid]
+                                    .GuestCharacterMap[nextGrid.DungeonGridGuid]
                                     .Select(d=>DungeonBattleGuestTable.GetById(d).CharacterId);
                                 var infos = battleInfoResponse.UserDungeonBattleGuestCharacterDtoInfos
                                     .Where(d => characterIds.Contains(d.CharacterId))


### PR DESCRIPTION
When the next grid is a JoinCharacter (support character) grid, `AutoDungeonBattle` looks up `GuestCharacterMap` with the current grid's GUID. The map is keyed by the JoinCharacter grid's GUID, so this throws `KeyNotFoundException` and aborts the whole dungeon run:

```
System.Collections.Generic.KeyNotFoundException: The given key 'c9f6917b86a6486c805861dec2aae761' was not present in the dictionary.
   at MementoMori.Funcs.MementoMoriFuncs.AutoDungeonBattle(Action`1 log, CancellationToken cancellationToken) in /src/MementoMori/Funcs/DungeonBattle.cs:line 370
```

Fixed by using `nextGrid.DungeonGridGuid`, consistent with the `ExecGuestRequest` below. Verified locally: an account stuck on a JoinCharacter grid now clears all 3 layers normally.